### PR TITLE
refactor: add guide to setup supabase tables for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,9 @@ Thank you for your interest in contributing to Pipeline! We welcome contribution
 | bank_acct      | text |                   |         | True      |          |                 |
 | wallet_address | text |                   |         | True      |          |                 |
 | funding_goal   | text |                   |         |           |          |                 |
+| user_id        | text |                   |         |           |          |                 |
+| image          | text |                   |         |           |          |                 |
+| banner_image   | text |                   |         |           |          |                 |
 
 ## Reporting Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,34 @@ Thank you for your interest in contributing to Pipeline! We welcome contribution
 - Write clear, concise comments.
 - Keep functions small and focused on a single task.
 
+## Supabase Guide For Tables
+
+- Create your supabase project with the [Supabase setup guide](https://supabase.com/docs/guides/getting-started),
+- Select the **Database** tab on the sidebar
+- Select on **Tables**
+- Click on **New Table** and add the following tables with their fields _(leave the default fields untouched)_:
+
+> Table Name: projects
+
+| Name           | Type | Default Value     | Primary | Is Unique | Nullable | Define As Array |
+| -------------- | ---- | ----------------- | ------- | --------- | -------- | --------------- |
+| id             | uuid | gen_random_uuid() | Yes     | True      |          |                 |
+| title          | text |                   |         |           |          |                 |
+| bio            | text |                   |         |           |          |                 |
+| tags           | text |                   |         |           |          | Yes             |
+| country        | text |                   |         |           |          |                 |
+| details        | text |                   |         |           |          |                 |
+| email          | text |                   |         | True      |          |                 |
+| portfolio      | text |                   |         | True      |          |                 |
+| github_repo    | text |                   |         | True      |          |                 |
+| linkedin       | text |                   |         | True      |          |                 |
+| twitter        | text |                   |         | True      |          |                 |
+| website        | text |                   |         | True      |          |                 |
+| other          | text |                   |         |           |          |                 |
+| bank_acct      | text |                   |         | True      |          |                 |
+| wallet_address | text |                   |         | True      |          |                 |
+| funding_goal   | text |                   |         |           |          |                 |
+
 ## Reporting Issues
 
 If you find a bug or have a suggestion for improvement:

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ DPG Pipeline is a web-based platform built with **SvelteKit** and **NodeJS** usi
    ```sh
    npm run dev
    ```
+
+## Want to Contribute?
+
+Follow the [Contributing Guide](./CONTRIBUTING.md) for steps and requirements.


### PR DESCRIPTION
Adds table in the CONTRIBUTING.md file of all tables and fields needed to setup supabase correctly for local development.
> as a bonus add a section that points to the contributing file for anyone interested in contributing.

- if we could get a screenshot of the schema visualizer on supabase, that would speed up the process faster, and probably no need for this tables 
- also we could separate this info to a new file or leave it in this same file but pushed at the bottom.

**Current Tables**
- [X] projects 
- [ ] user 
- [ ] category_project
- [ ] categories
- [ ] dpg_status
- [ ] project_dpg_status
- [ ] project_resource
- [ ] project_update_comment
- [ ] project_updates

closes #121 