### PR TITLE
add github actions for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Pull_Request_CI
+
+on:
+  pull_request:
+    types: [opened, reopened, review_requested]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Run formatter
+        run: npm run format
+        working-directory: .
+
+      # - name: Running tests...
+      #   run: npm run test
+      #   working-directory: .


### PR DESCRIPTION
would be nice to add after #223 but it can still be merged before that.
the actions currently are only activated when a new PR is created and only formatting is included for now.
#223 makes it easy since it's already configured with the correct formatting options and will allow this PR to work without failing.

fixes #111 