### PR TITLE
Fetch only the published project in explore page and when searching

### DIFF
--- a/src/lib/server/repo/projectRepo.js
+++ b/src/lib/server/repo/projectRepo.js
@@ -22,6 +22,7 @@ export async function getProjectsWithCategories(term, start, end, supabase) {
       current_funding,
       user_id,
       bio,
+      published_at,
       dpgStatus,
       category_project!inner (
         categories!inner (
@@ -30,6 +31,9 @@ export async function getProjectsWithCategories(term, start, end, supabase) {
       )
     `,
   );
+
+  // Only show published projects on explore page
+  query = query.not('published_at', 'is', null);
 
   // Conditionally add search filter only if term is provided
   if (term && term.trim() !== '') {
@@ -99,6 +103,7 @@ export async function getProjectsByUserIdWithCategories(userId, start, end, supa
     funding_goal,
     current_funding,
     user_id,
+    published_at,
     dpgStatus,
     category_project!inner (
       categories!inner (


### PR DESCRIPTION
Updated the project fetching logic to improve visibility and user experience. On the Explore page and during project search, only published projects (published_at set) are now displayed. However, on the user Profile page, all projects are shown — including unpublished ones — to allow users to view and manage their drafts privately