### PR TITLE
feat(export): add data extraction exports for users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@
 - **Activity Feeds**: Stay updated with project developments and community activity
 - **Mobile-Responsive Design**: Seamless experience across all devices
 
+### 📤 **Data Portability**
+- **One-Click Data Download**: Users can download their account data directly from profile
+- **Multiple Export Formats**: Exports are available in JSON (default) and CSV formats
+- **Secure Export Access**: Project exports are restricted to project owners and project team members
+- **Export Safeguards**: Per-user rate limiting and record caps protect performance and prevent abuse
+
 ### 🔐 **Security & Authentication**
 - **Secure Authentication**: Supabase-powered authentication with social login options
 - **Content Security Policy**: Comprehensive CSP implementation for enhanced security
@@ -272,65 +278,6 @@ To enable real-time GitHub integration and automated project updates:
 6. Click **Add webhook**
 
 This enables automatic synchronization of project data with GitHub repositories.
-
-## 📤 Data Export APIs
-
-Pipeline supports authenticated data exports in `JSON` and `CSV` formats:
-
-- `GET /api/profile/export?format=json|csv`
-- `GET /api/projects/:id/export?format=json|csv`
-
-### Authentication and Authorization
-
-- Both endpoints require authentication. Unauthenticated requests return `401 Unauthorized`.
-- `GET /api/profile/export` exports only the currently authenticated user's data.
-- `GET /api/projects/:id/export` is authorized for:
-  - The project owner (`projects.user_id === requester id`)
-  - Project team members with a matching membership row in `project_members` (`project_id = :id` and `user_id = requester id`)
-- Project export authorization failures return `403 Forbidden`. Unknown projects return `404 Not Found`.
-
-### Exported Data Fields
-
-- Profile export (`/api/profile/export`) includes:
-  - `exported_at` timestamp
-  - `user`: authenticated `user_id` and profile data (can include PII such as contact/account profile details)
-  - `projects`: projects created by the user
-  - `contributions`: `project_resource` entries created by the user
-  - `bookmarks`: bookmarked project IDs and bookmark timestamps
-  - `updates`: project updates created by the user
-  - `comments`: update comments created by the user
-- Project export (`/api/projects/:id/export`) includes:
-  - `exported_at` timestamp
-  - `project`: project record (owner export may include full project fields; team-member export excludes sensitive fields like bank account, wallet address, and email)
-  - Project resources, updates, update comments, categories, and member metadata with timestamps where present in source tables
-
-### Response Format and Headers
-
-- Successful responses are file downloads (`Content-Disposition: attachment; filename="..."`), not inline API JSON pages.
-- `format=json` returns `Content-Type: application/json`.
-- `format=csv` returns `Content-Type: text/csv; charset=utf-8`.
-- `Cache-Control` is `no-store` for both endpoints.
-
-### Limits and Error Responses
-
-- Supported `format` values are `json` and `csv` (`400 Bad Request` for invalid format).
-- There are currently no endpoint-specific rate-limit or export-size caps implemented in application code.
-- Deployments may still enforce upstream/provider limits; clients should handle:
-  - `413 Payload Too Large` for provider-enforced response-size limits
-  - `429 Too Many Requests` for provider or edge rate limiting
-- Other expected responses:
-  - `401 Unauthorized` (no authenticated session)
-  - `403 Forbidden` (project export without owner/member access)
-  - `404 Not Found` (project export for unknown project)
-  - `500 Internal Server Error` (unexpected server failure)
-
-### Privacy, Portability, Retention, and Deletion
-
-- These exports support data portability workflows and are aligned with GDPR Article 20 (Right to Data Portability).
-- DPG Pipeline privacy posture also considers CCPA user rights around access and deletion requests.
-- Retention windows and deletion handling follow platform data-handling/legal policies; see:
-  - Privacy policy: https://pipeline-tau.vercel.app/privacy
-  - Data handling/legal documentation: [DPG Criterion 7 Privacy & Legal](./docs/DPG_CRITERION_7_PRIVACY_LEGAL.md)
 
 ## 📚 Documentation
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ npm run check:watch
 npm run format
 ```
 
+### Data Export APIs
+
+Pipeline supports user/project data export in `JSON` and `CSV` formats:
+
+- `GET /api/profile/export?format=json|csv`
+  - Returns the authenticated user's data export file
+- `GET /api/projects/:id/export?format=json|csv`
+  - Returns project export data for project owners/team members
+
 ## 📁 Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -161,15 +161,6 @@ npm run check:watch
 npm run format
 ```
 
-### Data Export APIs
-
-Pipeline supports user/project data export in `JSON` and `CSV` formats:
-
-- `GET /api/profile/export?format=json|csv`
-  - Returns the authenticated user's data export file
-- `GET /api/projects/:id/export?format=json|csv`
-  - Returns project export data for project owners/team members
-
 ## 📁 Project Structure
 
 ```
@@ -281,6 +272,65 @@ To enable real-time GitHub integration and automated project updates:
 6. Click **Add webhook**
 
 This enables automatic synchronization of project data with GitHub repositories.
+
+## 📤 Data Export APIs
+
+Pipeline supports authenticated data exports in `JSON` and `CSV` formats:
+
+- `GET /api/profile/export?format=json|csv`
+- `GET /api/projects/:id/export?format=json|csv`
+
+### Authentication and Authorization
+
+- Both endpoints require authentication. Unauthenticated requests return `401 Unauthorized`.
+- `GET /api/profile/export` exports only the currently authenticated user's data.
+- `GET /api/projects/:id/export` is authorized for:
+  - The project owner (`projects.user_id === requester id`)
+  - Project team members with a matching membership row in `project_members` (`project_id = :id` and `user_id = requester id`)
+- Project export authorization failures return `403 Forbidden`. Unknown projects return `404 Not Found`.
+
+### Exported Data Fields
+
+- Profile export (`/api/profile/export`) includes:
+  - `exported_at` timestamp
+  - `user`: authenticated `user_id` and profile data (can include PII such as contact/account profile details)
+  - `projects`: projects created by the user
+  - `contributions`: `project_resource` entries created by the user
+  - `bookmarks`: bookmarked project IDs and bookmark timestamps
+  - `updates`: project updates created by the user
+  - `comments`: update comments created by the user
+- Project export (`/api/projects/:id/export`) includes:
+  - `exported_at` timestamp
+  - `project`: project record (owner export may include full project fields; team-member export excludes sensitive fields like bank account, wallet address, and email)
+  - Project resources, updates, update comments, categories, and member metadata with timestamps where present in source tables
+
+### Response Format and Headers
+
+- Successful responses are file downloads (`Content-Disposition: attachment; filename="..."`), not inline API JSON pages.
+- `format=json` returns `Content-Type: application/json`.
+- `format=csv` returns `Content-Type: text/csv; charset=utf-8`.
+- `Cache-Control` is `no-store` for both endpoints.
+
+### Limits and Error Responses
+
+- Supported `format` values are `json` and `csv` (`400 Bad Request` for invalid format).
+- There are currently no endpoint-specific rate-limit or export-size caps implemented in application code.
+- Deployments may still enforce upstream/provider limits; clients should handle:
+  - `413 Payload Too Large` for provider-enforced response-size limits
+  - `429 Too Many Requests` for provider or edge rate limiting
+- Other expected responses:
+  - `401 Unauthorized` (no authenticated session)
+  - `403 Forbidden` (project export without owner/member access)
+  - `404 Not Found` (project export for unknown project)
+  - `500 Internal Server Error` (unexpected server failure)
+
+### Privacy, Portability, Retention, and Deletion
+
+- These exports support data portability workflows and are aligned with GDPR Article 20 (Right to Data Portability).
+- DPG Pipeline privacy posture also considers CCPA user rights around access and deletion requests.
+- Retention windows and deletion handling follow platform data-handling/legal policies; see:
+  - Privacy policy: https://pipeline-tau.vercel.app/privacy
+  - Data handling/legal documentation: [DPG Criterion 7 Privacy & Legal](./docs/DPG_CRITERION_7_PRIVACY_LEGAL.md)
 
 ## 📚 Documentation
 

--- a/src/lib/server/service/exportService.js
+++ b/src/lib/server/service/exportService.js
@@ -23,7 +23,7 @@ function stringifyCell(value) {
  * @returns {string}
  */
 function escapeCsv(value) {
-  if (value.includes('"') || value.includes(',') || value.includes('\n')) {
+  if (value.includes('"') || value.includes(',') || /[\r\n]/.test(value)) {
     return `"${value.replace(/"/g, '""')}"`;
   }
 
@@ -40,7 +40,7 @@ export function toCsv(rows) {
   }
 
   const headers = [...new Set(rows.flatMap((row) => Object.keys(row)))];
-  const headerRow = headers.join(',');
+  const headerRow = headers.map((header) => escapeCsv(header)).join(',');
   const body = rows
     .map((row) =>
       headers.map((header) => escapeCsv(stringifyCell(row[header] ?? ''))).join(','),

--- a/src/lib/server/service/exportService.js
+++ b/src/lib/server/service/exportService.js
@@ -2,6 +2,75 @@
 
 import { getProfile } from '$lib/server/repo/userProfileRepo.js';
 
+export const EXPORT_MAX_RECORDS = 10000;
+export const EXPORT_RATE_LIMIT_MAX = 10;
+export const EXPORT_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+/** @type {Map<string, number[]>} */
+const exportRequestLog = new Map();
+
+/**
+ * @param {string} userId
+ * @param {number} now
+ * @returns {number[]}
+ */
+function getWindowedRequests(userId, now) {
+  const windowStart = now - EXPORT_RATE_LIMIT_WINDOW_MS;
+  const existing = exportRequestLog.get(userId) || [];
+  const windowed = existing.filter((timestamp) => timestamp > windowStart);
+  exportRequestLog.set(userId, windowed);
+  return windowed;
+}
+
+/**
+ * @param {string} userId
+ * @returns {{allowed: boolean, remaining: number, retryAfterSeconds: number}}
+ */
+export function consumeExportRateLimit(userId) {
+  const now = Date.now();
+  const windowed = getWindowedRequests(userId, now);
+
+  if (windowed.length >= EXPORT_RATE_LIMIT_MAX) {
+    const oldest = windowed[0];
+    const retryAfterMs = Math.max(0, oldest + EXPORT_RATE_LIMIT_WINDOW_MS - now);
+
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+    };
+  }
+
+  windowed.push(now);
+  exportRequestLog.set(userId, windowed);
+
+  return {
+    allowed: true,
+    remaining: Math.max(0, EXPORT_RATE_LIMIT_MAX - windowed.length),
+    retryAfterSeconds: 0,
+  };
+}
+
+/**
+ * @param {string} label
+ * @param {Array<unknown>} records
+ */
+function assertWithinRecordCap(label, records) {
+  if (records.length > EXPORT_MAX_RECORDS) {
+    throw new Error(
+      `Export exceeds maximum record cap for ${label}. Please narrow your request or split the export.`,
+    );
+  }
+}
+
+/**
+ * @param {Record<string, unknown>} payload
+ * @returns {number}
+ */
+export function getExportRowCount(payload) {
+  return toReadableRows(payload).length;
+}
+
 /**
  * @param {unknown} value
  * @returns {string}
@@ -16,6 +85,26 @@ function stringifyCell(value) {
   }
 
   return String(value);
+}
+
+/**
+ * @param {string} key
+ * @returns {string}
+ */
+function humanizeKey(key) {
+  const normalized = key.replace(/[_-]+/g, ' ').trim();
+  if (!normalized) return key;
+
+  return normalized
+    .split(' ')
+    .map((word) => {
+      const lower = word.toLowerCase();
+      if (lower === 'id') return 'ID';
+      if (lower === 'url') return 'URL';
+      if (lower === 'api') return 'API';
+      return `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`;
+    })
+    .join(' ');
 }
 
 /**
@@ -110,6 +199,104 @@ export function toPathRows(payload) {
 }
 
 /**
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function toReadableCellValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return value;
+}
+
+/**
+ * Produces a spreadsheet-friendly CSV row model:
+ * one row per logical record, with section and record index columns.
+ * @param {Record<string, unknown>} payload
+ * @returns {Array<Record<string, unknown>>}
+ */
+export function toReadableRows(payload) {
+  /** @type {Array<Record<string, unknown>>} */
+  const rows = [];
+  const exportedAt = payload.exported_at || '';
+  const accessRole = payload.access_role || '';
+  const metadataColumns = {
+    section: 'Section',
+    recordIndex: 'Record Number',
+    exportedAt: 'Export Date',
+    accessRole: 'Access Role',
+    note: 'Note',
+    value: 'Value',
+  };
+
+  Object.entries(payload).forEach(([section, sectionValue]) => {
+    if (section === 'exported_at' || section === 'access_role') {
+      return;
+    }
+
+    if (Array.isArray(sectionValue)) {
+      if (!sectionValue.length) {
+        rows.push({
+          [metadataColumns.section]: humanizeKey(section),
+          [metadataColumns.recordIndex]: '',
+          [metadataColumns.exportedAt]: exportedAt,
+          [metadataColumns.accessRole]: accessRole,
+          [metadataColumns.note]: 'No records',
+        });
+        return;
+      }
+
+      sectionValue.forEach((record, index) => {
+        /** @type {Record<string, unknown>} */
+        const row = {
+          [metadataColumns.section]: humanizeKey(section),
+          [metadataColumns.recordIndex]: index + 1,
+          [metadataColumns.exportedAt]: exportedAt,
+          [metadataColumns.accessRole]: accessRole,
+        };
+
+        if (record !== null && typeof record === 'object' && !Array.isArray(record)) {
+          Object.entries(record).forEach(([key, value]) => {
+            row[humanizeKey(key)] = toReadableCellValue(value);
+          });
+        } else {
+          row[metadataColumns.value] = toReadableCellValue(record);
+        }
+
+        rows.push(row);
+      });
+
+      return;
+    }
+
+    /** @type {Record<string, unknown>} */
+    const row = {
+      [metadataColumns.section]: humanizeKey(section),
+      [metadataColumns.recordIndex]: 1,
+      [metadataColumns.exportedAt]: exportedAt,
+      [metadataColumns.accessRole]: accessRole,
+    };
+
+    if (sectionValue !== null && typeof sectionValue === 'object') {
+      Object.entries(sectionValue).forEach(([key, value]) => {
+        row[humanizeKey(key)] = toReadableCellValue(value);
+      });
+    } else {
+      row[metadataColumns.value] = toReadableCellValue(sectionValue);
+    }
+
+    rows.push(row);
+  });
+
+  return rows;
+}
+
+/**
  * @param {Record<string, unknown>} project
  * @returns {Record<string, unknown>}
  */
@@ -133,32 +320,47 @@ export async function getUserExportData(userId, supabase) {
     { data: updates, error: updatesError },
     { data: comments, error: commentsError },
   ] = await Promise.all([
-    supabase.from('projects').select('*').eq('user_id', userId).order('created_at', { ascending: false }),
+    supabase
+      .from('projects')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('project_resource')
       .select('*')
       .eq('user_id', userId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('bookmark_project')
       .select('project_id, created_at')
       .eq('user_id', userId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('project_updates')
       .select('*')
       .eq('user_id', userId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('project_update_comment')
       .select('*')
       .eq('user_id', userId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
   ]);
 
   if (projectError || resourceError || bookmarkError || updatesError || commentsError) {
     throw new Error('Failed to collect user export data');
   }
+
+  assertWithinRecordCap('projects', projects || []);
+  assertWithinRecordCap('contributions', resources || []);
+  assertWithinRecordCap('bookmarks', bookmarks || []);
+  assertWithinRecordCap('updates', updates || []);
+  assertWithinRecordCap('comments', comments || []);
 
   return {
     exported_at: new Date().toISOString(),
@@ -219,32 +421,43 @@ export async function getProjectExportData(projectId, requesterId, supabase) {
     supabase
       .from('category_project')
       .select('category_id, categories(title, sdg_id)')
-      .eq('project_id', projectId),
+      .eq('project_id', projectId)
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('project_resource')
       .select('*')
       .eq('project_id', projectId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('project_updates')
       .select('*')
       .eq('project_id', projectId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('project_update_comment')
       .select('*')
       .eq('project_id', projectId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
     supabase
       .from('project_members')
       .select('user_id, creator_id, created_at')
       .eq('project_id', projectId)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(EXPORT_MAX_RECORDS + 1),
   ]);
 
   if (categoryError || resourcesError || updatesError || commentsError || membersError) {
     throw new Error('Failed to collect project export data');
   }
+
+  assertWithinRecordCap('categories', categories || []);
+  assertWithinRecordCap('resources', resources || []);
+  assertWithinRecordCap('updates', updates || []);
+  assertWithinRecordCap('comments', comments || []);
+  assertWithinRecordCap('members', members || []);
 
   const role = isOwner ? 'owner' : 'team_member';
 

--- a/src/lib/server/service/exportService.js
+++ b/src/lib/server/service/exportService.js
@@ -1,0 +1,264 @@
+//@ts-check
+
+import { getProfile } from '$lib/server/repo/userProfileRepo.js';
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function stringifyCell(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeCsv(value) {
+  if (value.includes('"') || value.includes(',') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+
+  return value;
+}
+
+/**
+ * @param {Array<Record<string, unknown>>} rows
+ * @returns {string}
+ */
+export function toCsv(rows) {
+  if (!rows.length) {
+    return 'section,path,value\n';
+  }
+
+  const headers = [...new Set(rows.flatMap((row) => Object.keys(row)))];
+  const headerRow = headers.join(',');
+  const body = rows
+    .map((row) =>
+      headers.map((header) => escapeCsv(stringifyCell(row[header] ?? ''))).join(','),
+    )
+    .join('\n');
+
+  return `${headerRow}\n${body}\n`;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} path
+ * @param {Array<{path: string, value: string}>} acc
+ */
+function flattenToPathRows(value, path, acc) {
+  if (Array.isArray(value)) {
+    if (!value.length) {
+      acc.push({ path, value: '[]' });
+      return;
+    }
+
+    value.forEach((item, index) => flattenToPathRows(item, `${path}[${index}]`, acc));
+    return;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value);
+
+    if (!entries.length) {
+      acc.push({ path, value: '{}' });
+      return;
+    }
+
+    entries.forEach(([key, item]) => {
+      const nextPath = path ? `${path}.${key}` : key;
+      flattenToPathRows(item, nextPath, acc);
+    });
+    return;
+  }
+
+  acc.push({ path, value: stringifyCell(value) });
+}
+
+/**
+ * @param {Record<string, unknown>} payload
+ * @returns {Array<{section: string, path: string, value: string}>}
+ */
+export function toPathRows(payload) {
+  /** @type {Array<{section: string, path: string, value: string}>} */
+  const rows = [];
+
+  Object.entries(payload).forEach(([section, sectionValue]) => {
+    /** @type {Array<{path: string, value: string}>} */
+    const flatRows = [];
+    flattenToPathRows(sectionValue, '', flatRows);
+
+    flatRows.forEach((flatRow) => {
+      rows.push({
+        section,
+        path: flatRow.path || section,
+        value: flatRow.value,
+      });
+    });
+  });
+
+  return rows;
+}
+
+/**
+ * @param {Record<string, unknown>} project
+ * @returns {Record<string, unknown>}
+ */
+function sanitizeProjectForTeamExport(project) {
+  const { bank_acct, wallet_address, email, ...safeProject } = project;
+  return safeProject;
+}
+
+/**
+ * @param {string} userId
+ * @param {any} supabase
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function getUserExportData(userId, supabase) {
+  const profile = await getProfile(userId, supabase);
+
+  const [
+    { data: projects, error: projectError },
+    { data: resources, error: resourceError },
+    { data: bookmarks, error: bookmarkError },
+    { data: updates, error: updatesError },
+    { data: comments, error: commentsError },
+  ] = await Promise.all([
+    supabase.from('projects').select('*').eq('user_id', userId).order('created_at', { ascending: false }),
+    supabase
+      .from('project_resource')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('bookmark_project')
+      .select('project_id, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('project_updates')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('project_update_comment')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false }),
+  ]);
+
+  if (projectError || resourceError || bookmarkError || updatesError || commentsError) {
+    throw new Error('Failed to collect user export data');
+  }
+
+  return {
+    exported_at: new Date().toISOString(),
+    user: {
+      user_id: userId,
+      profile,
+    },
+    projects: projects || [],
+    contributions: resources || [],
+    bookmarks: bookmarks || [],
+    updates: updates || [],
+    comments: comments || [],
+  };
+}
+
+/**
+ * @param {string} projectId
+ * @param {string} requesterId
+ * @param {any} supabase
+ * @returns {Promise<{data: Record<string, unknown>, role: 'owner' | 'team_member'}>}
+ */
+export async function getProjectExportData(projectId, requesterId, supabase) {
+  const { data: project, error: projectError } = await supabase
+    .from('projects')
+    .select('*')
+    .eq('id', projectId)
+    .single();
+
+  if (projectError || !project) {
+    throw new Error('Project not found');
+  }
+
+  const { data: membership, error: memberError } = await supabase
+    .from('project_members')
+    .select('user_id, creator_id')
+    .eq('project_id', projectId)
+    .eq('user_id', requesterId)
+    .maybeSingle();
+
+  if (memberError) {
+    throw new Error('Failed to validate project membership');
+  }
+
+  const isOwner = project.user_id === requesterId;
+  const isTeamMember = !!membership;
+
+  if (!isOwner && !isTeamMember) {
+    throw new Error('Unauthorized');
+  }
+
+  const [
+    { data: categories, error: categoryError },
+    { data: resources, error: resourcesError },
+    { data: updates, error: updatesError },
+    { data: comments, error: commentsError },
+    { data: members, error: membersError },
+  ] = await Promise.all([
+    supabase
+      .from('category_project')
+      .select('category_id, categories(title, sdg_id)')
+      .eq('project_id', projectId),
+    supabase
+      .from('project_resource')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('project_updates')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('project_update_comment')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('project_members')
+      .select('user_id, creator_id, created_at')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false }),
+  ]);
+
+  if (categoryError || resourcesError || updatesError || commentsError || membersError) {
+    throw new Error('Failed to collect project export data');
+  }
+
+  const role = isOwner ? 'owner' : 'team_member';
+
+  return {
+    role,
+    data: {
+      exported_at: new Date().toISOString(),
+      access_role: role,
+      project: isOwner ? project : sanitizeProjectForTeamExport(project),
+      categories: categories || [],
+      resources: resources || [],
+      updates: updates || [],
+      comments: comments || [],
+      members: members || [],
+    },
+  };
+}

--- a/src/lib/server/service/exportService.test.js
+++ b/src/lib/server/service/exportService.test.js
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { toCsv, toPathRows } from './exportService.js';
+import {
+  consumeExportRateLimit,
+  EXPORT_RATE_LIMIT_MAX,
+  toReadableRows,
+  toCsv,
+  toPathRows,
+} from './exportService.js';
 
 describe('exportService', () => {
   it('flattens nested payload into section/path/value rows', () => {
@@ -27,5 +33,45 @@ describe('exportService', () => {
 
     expect(csv).toContain('section,path,value');
     expect(csv).toContain('"Writes, tests, and ""ships"""');
+  });
+
+  it('creates readable tabular rows for csv exports', () => {
+    const rows = toReadableRows({
+      exported_at: '2026-03-03T10:00:00.000Z',
+      access_role: 'owner',
+      user: { user_id: 'u1', profile: { name: 'Ada' } },
+      projects: [{ id: 'p1', title: 'Project One' }],
+    });
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          Section: 'User',
+          'Record Number': 1,
+          'Export Date': '2026-03-03T10:00:00.000Z',
+          'Access Role': 'owner',
+          'User ID': 'u1',
+        }),
+        expect.objectContaining({
+          Section: 'Projects',
+          'Record Number': 1,
+          ID: 'p1',
+          Title: 'Project One',
+        }),
+      ]),
+    );
+  });
+
+  it('enforces per-user export rate limiting', () => {
+    const userId = `rate-limit-user-${Date.now()}`;
+
+    for (let i = 0; i < EXPORT_RATE_LIMIT_MAX; i++) {
+      const result = consumeExportRateLimit(userId);
+      expect(result.allowed).toBe(true);
+    }
+
+    const blocked = consumeExportRateLimit(userId);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
   });
 });

--- a/src/lib/server/service/exportService.test.js
+++ b/src/lib/server/service/exportService.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { toCsv, toPathRows } from './exportService.js';
+
+describe('exportService', () => {
+  it('flattens nested payload into section/path/value rows', () => {
+    const payload = {
+      user: { id: 'u1', profile: { name: 'Ada' } },
+      projects: [{ id: 'p1', title: 'Project One' }],
+    };
+
+    const rows = toPathRows(payload);
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { section: 'user', path: 'id', value: 'u1' },
+        { section: 'user', path: 'profile.name', value: 'Ada' },
+        { section: 'projects', path: '[0].id', value: 'p1' },
+      ]),
+    );
+  });
+
+  it('creates a csv with headers and escaped values', () => {
+    const csv = toCsv([
+      { section: 'user', path: 'profile.name', value: 'Ada Lovelace' },
+      { section: 'user', path: 'profile.bio', value: 'Writes, tests, and "ships"' },
+    ]);
+
+    expect(csv).toContain('section,path,value');
+    expect(csv).toContain('"Writes, tests, and ""ships"""');
+  });
+});

--- a/src/routes/api/profile/export/+server.js
+++ b/src/routes/api/profile/export/+server.js
@@ -1,0 +1,46 @@
+import { getUserExportData, toCsv, toPathRows } from '$lib/server/service/exportService.js';
+import { json } from '@sveltejs/kit';
+
+/**
+ * @param {'json' | 'csv'} format
+ * @param {string} userId
+ */
+function getExportHeaders(format, userId) {
+  const filename = `pipeline-user-export-${userId}-${new Date().toISOString().split('T')[0]}.${format}`;
+  const contentType = format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json';
+
+  return {
+    'Content-Disposition': `attachment; filename="${filename}"`,
+    'Cache-Control': 'no-store',
+    'Content-Type': contentType,
+  };
+}
+
+export async function GET({ url, locals }) {
+  const format = (url.searchParams.get('format') || 'json').toLowerCase();
+  const authUser = locals.authUser;
+  const supabase = locals.supabase;
+
+  if (!authUser) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (format !== 'json' && format !== 'csv') {
+    return json({ error: "Invalid format. Use 'json' or 'csv'" }, { status: 400 });
+  }
+
+  try {
+    const payload = await getUserExportData(authUser.id, supabase);
+    const headers = getExportHeaders(format, authUser.id);
+
+    if (format === 'csv') {
+      const rows = toPathRows(payload);
+      const csv = toCsv(rows);
+      return new Response(csv, { status: 200, headers });
+    }
+
+    return new Response(JSON.stringify(payload, null, 2), { status: 200, headers });
+  } catch (error) {
+    return json({ error: error.message || 'Failed to export data' }, { status: 500 });
+  }
+}

--- a/src/routes/api/profile/export/+server.js
+++ b/src/routes/api/profile/export/+server.js
@@ -41,6 +41,7 @@ export async function GET({ url, locals }) {
 
     return new Response(JSON.stringify(payload, null, 2), { status: 200, headers });
   } catch (error) {
-    return json({ error: error.message || 'Failed to export data' }, { status: 500 });
+    console.error('Profile export failed', { error, userId: authUser?.id });
+    return json({ error: 'Failed to export data' }, { status: 500 });
   }
 }

--- a/src/routes/api/profile/export/+server.js
+++ b/src/routes/api/profile/export/+server.js
@@ -1,4 +1,13 @@
-import { getUserExportData, toCsv, toPathRows } from '$lib/server/service/exportService.js';
+import {
+  consumeExportRateLimit,
+  EXPORT_MAX_RECORDS,
+  EXPORT_RATE_LIMIT_MAX,
+  EXPORT_RATE_LIMIT_WINDOW_MS,
+  getExportRowCount,
+  getUserExportData,
+  toCsv,
+  toReadableRows,
+} from '$lib/server/service/exportService.js';
 import { json } from '@sveltejs/kit';
 
 /**
@@ -6,7 +15,12 @@ import { json } from '@sveltejs/kit';
  * @param {string} userId
  */
 function getExportHeaders(format, userId) {
-  const filename = `pipeline-user-export-${userId}-${new Date().toISOString().split('T')[0]}.${format}`;
+  const sanitizedUserId = userId
+    .replace(/[\r\n"]/g, '')
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .slice(0, 64);
+  const safeUserId = sanitizedUserId || 'user';
+  const filename = `pipeline-user-export-${safeUserId}-${new Date().toISOString().split('T')[0]}.${format}`;
   const contentType = format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json';
 
   return {
@@ -29,19 +43,46 @@ export async function GET({ url, locals }) {
     return json({ error: "Invalid format. Use 'json' or 'csv'" }, { status: 400 });
   }
 
+  const rateCheck = consumeExportRateLimit(authUser.id);
+  if (!rateCheck.allowed) {
+    return json(
+      { error: 'Rate limit exceeded. Please retry later.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(rateCheck.retryAfterSeconds),
+          'X-RateLimit-Limit': String(EXPORT_RATE_LIMIT_MAX),
+          'X-RateLimit-Remaining': String(rateCheck.remaining),
+        },
+      },
+    );
+  }
+
   try {
     const payload = await getUserExportData(authUser.id, supabase);
     const headers = getExportHeaders(format, authUser.id);
+    const rowCount = getExportRowCount(payload);
+    const metricsHeaders = {
+      'X-RateLimit-Limit': String(EXPORT_RATE_LIMIT_MAX),
+      'X-RateLimit-Remaining': String(rateCheck.remaining),
+      'X-Export-Row-Count': String(rowCount),
+      'X-Export-Record-Cap': String(EXPORT_MAX_RECORDS),
+      'X-Export-Window-Ms': String(EXPORT_RATE_LIMIT_WINDOW_MS),
+    };
 
     if (format === 'csv') {
-      const rows = toPathRows(payload);
+      const rows = toReadableRows(payload);
       const csv = toCsv(rows);
-      return new Response(csv, { status: 200, headers });
+      return new Response(csv, { status: 200, headers: { ...headers, ...metricsHeaders } });
     }
 
-    return new Response(JSON.stringify(payload, null, 2), { status: 200, headers });
+    return new Response(JSON.stringify(payload, null, 2), {
+      status: 200,
+      headers: { ...headers, ...metricsHeaders },
+    });
   } catch (error) {
+    const status = error.message?.includes('record cap') ? 413 : 500;
     console.error('Profile export failed', { error, userId: authUser?.id });
-    return json({ error: 'Failed to export data' }, { status: 500 });
+    return json({ error: error.message || 'Failed to export data' }, { status });
   }
 }

--- a/src/routes/api/projects/[id]/export/+server.js
+++ b/src/routes/api/projects/[id]/export/+server.js
@@ -1,4 +1,13 @@
-import { getProjectExportData, toCsv, toPathRows } from '$lib/server/service/exportService.js';
+import {
+  consumeExportRateLimit,
+  EXPORT_MAX_RECORDS,
+  EXPORT_RATE_LIMIT_MAX,
+  EXPORT_RATE_LIMIT_WINDOW_MS,
+  getExportRowCount,
+  getProjectExportData,
+  toCsv,
+  toReadableRows,
+} from '$lib/server/service/exportService.js';
 import { json } from '@sveltejs/kit';
 
 /**
@@ -35,17 +44,43 @@ export async function GET({ params, url, locals }) {
     return json({ error: "Invalid format. Use 'json' or 'csv'" }, { status: 400 });
   }
 
+  const rateCheck = consumeExportRateLimit(authUser.id);
+  if (!rateCheck.allowed) {
+    return json(
+      { error: 'Rate limit exceeded. Please retry later.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(rateCheck.retryAfterSeconds),
+          'X-RateLimit-Limit': String(EXPORT_RATE_LIMIT_MAX),
+          'X-RateLimit-Remaining': String(rateCheck.remaining),
+        },
+      },
+    );
+  }
+
   try {
     const { data } = await getProjectExportData(projectId, authUser.id, supabase);
     const headers = getExportHeaders(format, projectId);
+    const rowCount = getExportRowCount(data);
+    const metricsHeaders = {
+      'X-RateLimit-Limit': String(EXPORT_RATE_LIMIT_MAX),
+      'X-RateLimit-Remaining': String(rateCheck.remaining),
+      'X-Export-Row-Count': String(rowCount),
+      'X-Export-Record-Cap': String(EXPORT_MAX_RECORDS),
+      'X-Export-Window-Ms': String(EXPORT_RATE_LIMIT_WINDOW_MS),
+    };
 
     if (format === 'csv') {
-      const rows = toPathRows(data);
+      const rows = toReadableRows(data);
       const csv = toCsv(rows);
-      return new Response(csv, { status: 200, headers });
+      return new Response(csv, { status: 200, headers: { ...headers, ...metricsHeaders } });
     }
 
-    return new Response(JSON.stringify(data, null, 2), { status: 200, headers });
+    return new Response(JSON.stringify(data, null, 2), {
+      status: 200,
+      headers: { ...headers, ...metricsHeaders },
+    });
   } catch (error) {
     if (error.message === 'Unauthorized') {
       return json({ error: 'Forbidden' }, { status: 403 });
@@ -55,7 +90,8 @@ export async function GET({ params, url, locals }) {
       return json({ error: 'Project not found' }, { status: 404 });
     }
 
+    const status = error.message?.includes('record cap') ? 413 : 500;
     console.error('Project export failed', { error, projectId, userId: authUser?.id });
-    return json({ error: 'Failed to export project data' }, { status: 500 });
+    return json({ error: error.message || 'Failed to export project data' }, { status });
   }
 }

--- a/src/routes/api/projects/[id]/export/+server.js
+++ b/src/routes/api/projects/[id]/export/+server.js
@@ -6,7 +6,12 @@ import { json } from '@sveltejs/kit';
  * @param {string} projectId
  */
 function getExportHeaders(format, projectId) {
-  const filename = `pipeline-project-export-${projectId}-${new Date().toISOString().split('T')[0]}.${format}`;
+  const sanitizedProjectId = projectId
+    .replace(/[\r\n"]/g, '')
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .slice(0, 64);
+  const safeProjectId = sanitizedProjectId || 'project';
+  const filename = `pipeline-project-export-${safeProjectId}-${new Date().toISOString().split('T')[0]}.${format}`;
   const contentType = format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json';
 
   return {
@@ -50,6 +55,7 @@ export async function GET({ params, url, locals }) {
       return json({ error: 'Project not found' }, { status: 404 });
     }
 
-    return json({ error: error.message || 'Failed to export project data' }, { status: 500 });
+    console.error('Project export failed', { error, projectId, userId: authUser?.id });
+    return json({ error: 'Failed to export project data' }, { status: 500 });
   }
 }

--- a/src/routes/api/projects/[id]/export/+server.js
+++ b/src/routes/api/projects/[id]/export/+server.js
@@ -1,0 +1,55 @@
+import { getProjectExportData, toCsv, toPathRows } from '$lib/server/service/exportService.js';
+import { json } from '@sveltejs/kit';
+
+/**
+ * @param {'json' | 'csv'} format
+ * @param {string} projectId
+ */
+function getExportHeaders(format, projectId) {
+  const filename = `pipeline-project-export-${projectId}-${new Date().toISOString().split('T')[0]}.${format}`;
+  const contentType = format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json';
+
+  return {
+    'Content-Disposition': `attachment; filename="${filename}"`,
+    'Cache-Control': 'no-store',
+    'Content-Type': contentType,
+  };
+}
+
+export async function GET({ params, url, locals }) {
+  const format = (url.searchParams.get('format') || 'json').toLowerCase();
+  const authUser = locals.authUser;
+  const supabase = locals.supabase;
+  const projectId = params.id;
+
+  if (!authUser) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (format !== 'json' && format !== 'csv') {
+    return json({ error: "Invalid format. Use 'json' or 'csv'" }, { status: 400 });
+  }
+
+  try {
+    const { data } = await getProjectExportData(projectId, authUser.id, supabase);
+    const headers = getExportHeaders(format, projectId);
+
+    if (format === 'csv') {
+      const rows = toPathRows(data);
+      const csv = toCsv(rows);
+      return new Response(csv, { status: 200, headers });
+    }
+
+    return new Response(JSON.stringify(data, null, 2), { status: 200, headers });
+  } catch (error) {
+    if (error.message === 'Unauthorized') {
+      return json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    if (error.message === 'Project not found') {
+      return json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    return json({ error: error.message || 'Failed to export project data' }, { status: 500 });
+  }
+}

--- a/src/routes/profile/(profile)/+layout.svelte
+++ b/src/routes/profile/(profile)/+layout.svelte
@@ -1,7 +1,7 @@
 <script>
   import { page } from '$app/stores';
   import Icon from '@iconify/svelte';
-  import { Button } from '$lib/components/ui/button';
+  import { toast } from 'svelte-sonner';
 
   export let data;
   const user = data.user;
@@ -49,6 +49,37 @@
   }
 
   $: activeTabIndex = getActiveTab(pathname);
+
+  /**
+   * @param {'json' | 'csv'} format
+   */
+  async function downloadMyData(format = 'json') {
+    try {
+      const response = await fetch(`/api/profile/export?format=${format}`);
+
+      if (!response.ok) {
+        throw new Error('Failed to export user data');
+      }
+
+      const blob = await response.blob();
+      const downloadUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+
+      const disposition = response.headers.get('content-disposition');
+      const filenameMatch = disposition?.match(/filename="(.+)"/);
+      const filename = filenameMatch?.[1] || `pipeline-user-export.${format}`;
+
+      link.href = downloadUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(downloadUrl);
+      toast.success(`Downloaded user data as ${format.toUpperCase()}`);
+    } catch (error) {
+      toast.error(error.message || 'Could not download user data');
+    }
+  }
 </script>
 
 <div class="min-h-screen bg-dashboard-black">
@@ -162,6 +193,15 @@
                   Edit Profile
                 </button>
               </a>
+
+              <button
+                on:click={() => downloadMyData('json')}
+                class="focus-ring flex w-full items-center justify-center gap-2 rounded-xl border border-dashboard-gray-600 bg-dashboard-gray-800 px-6 py-3 text-label-lg font-medium text-white transition-all duration-200 hover:scale-105 hover:bg-dashboard-gray-700"
+                type="button"
+              >
+                <Icon icon="mdi:download" class="h-5 w-5" />
+                Download My Data
+              </button>
             </div>
           </div>
         </div>

--- a/src/routes/profile/(profile)/+layout.svelte
+++ b/src/routes/profile/(profile)/+layout.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/stores';
   import Icon from '@iconify/svelte';
   import { toast } from 'svelte-sonner';
+  import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 
   export let data;
   const user = data.user;
@@ -53,7 +54,7 @@
   /**
    * @param {'json' | 'csv'} format
    */
-  async function downloadMyData(format = 'json') {
+  async function downloadMyData(format) {
     try {
       const response = await fetch(`/api/profile/export?format=${format}`);
 
@@ -194,14 +195,29 @@
                 </button>
               </a>
 
-              <button
-                on:click={() => downloadMyData('json')}
-                class="focus-ring flex w-full items-center justify-center gap-2 rounded-xl border border-dashboard-gray-600 bg-dashboard-gray-800 px-6 py-3 text-label-lg font-medium text-white transition-all duration-200 hover:scale-105 hover:bg-dashboard-gray-700"
-                type="button"
-              >
-                <Icon icon="mdi:download" class="h-5 w-5" />
-                Download My Data
-              </button>
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger
+                  class="focus-ring flex w-full items-center justify-center gap-2 rounded-xl border border-dashboard-gray-600 bg-dashboard-gray-800 px-6 py-3 text-label-lg font-medium text-white transition-all duration-200 hover:scale-105 hover:bg-dashboard-gray-700"
+                >
+                  <Icon icon="mdi:download" class="h-5 w-5" />
+                  Download My Data
+                  <Icon icon="mdi:chevron-down" class="h-5 w-5" />
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content class="z-50 min-w-[180px] rounded-xl border border-dashboard-gray-700 bg-dashboard-gray-900 p-1 text-white">
+                  <DropdownMenu.Item
+                    class="cursor-pointer rounded-lg px-3 py-2 text-sm hover:bg-dashboard-gray-800"
+                    on:click={() => downloadMyData('json')}
+                  >
+                    Download as JSON
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    class="cursor-pointer rounded-lg px-3 py-2 text-sm hover:bg-dashboard-gray-800"
+                    on:click={() => downloadMyData('csv')}
+                  >
+                    Download as CSV
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Root>
             </div>
           </div>
         </div>


### PR DESCRIPTION
  - add authenticated export endpoints for profile and project data (json and csv)
  - add export authorization + pii filtering for team-member access
  - add export safeguards (rate limiting + record caps)
  - improve csv output readability for non-technical users
  - update profile ui to let users choose export format (json/csv)
  - update readme feature section for data portability
  - add/expand export tests

progress towards #423 