### PR TITLE
docs: add ADR for request context abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ vite.config.ts.timestamp-*
 
 # Claude
 .claude
+
+# Worktrees
+.worktrees

--- a/docs/adr/0001-vendor-neutral-request-context.md
+++ b/docs/adr/0001-vendor-neutral-request-context.md
@@ -1,0 +1,229 @@
+# ADR 0001: Keep Vendor Clients Out of Routes
+
+## Status
+
+Proposed
+
+## Date
+
+2026-04-06
+
+## Context
+
+Pipeline currently exposes a request-scoped Supabase client as `event.locals.supabase`.
+Many routes either use that client directly or pass it through service and repository call sites.
+
+That has three practical problems:
+
+- route handlers know about a vendor-specific persistence client
+- replacing Supabase would require changing many route-level call sites
+- services and repositories do not have a single clear dependency flow
+
+This ADR is primarily about software design:
+
+- routes should depend on application behavior, not persistence details
+- services should coordinate business logic
+- repositories should isolate database access
+- vendor clients should stay behind those boundaries
+
+This also supports testing and reduces migration surface area.
+It is related to DPG Criterion 4, but that is a secondary benefit, not the main reason for the decision.
+
+## Decision
+
+Pipeline will use this request flow:
+
+- routes import service functions directly
+- services import repositories directly
+- repositories receive the database dependency
+- routes pass a small request context object into services when request-scoped dependencies are needed
+- services must not accept raw SvelteKit `locals`
+
+The target boundary shape is:
+
+```js
+// route
+import { getMembers } from '$lib/server/service/projectService.js';
+
+export async function GET({ params, locals }) {
+  const members = await getMembers(params.id, {
+    db: locals.db,
+    authUser: locals.authUser
+  });
+
+  return Response.json({ members });
+}
+
+// service
+import { listByProject } from '$lib/server/repo/memberRepo.js';
+
+export async function getMembers(projectId, ctx) {
+  return listByProject(projectId, ctx.db);
+}
+```
+
+This decision does not require a service container or per-request service factory in `hooks.server.js`.
+
+## Repository Contract
+
+Repositories remain the persistence boundary.
+
+Repository functions should:
+
+- expose application-oriented operations such as `listByProject(projectId, db)`
+- accept the database dependency explicitly
+- return plain values or throw errors
+- avoid framework-specific HTTP concerns
+
+Repository functions should not:
+
+- return SvelteKit response helpers
+- depend on route context
+- expose vendor-specific behavior above the repository layer
+
+This keeps the current repository style mostly intact while tightening how it is used.
+
+## Before and After
+
+### Before
+
+```js
+import { json } from '@sveltejs/kit';
+import { createProjectUpdate } from '$lib/server/service/projectUpdatesService.js';
+
+export async function POST({ params, request, locals }) {
+  const { title, body } = await request.json();
+
+  await createProjectUpdate(
+    {
+      project_id: params.id,
+      title,
+      body,
+      user_id: locals.authUser.id
+    },
+    locals.supabase
+  );
+
+  return json({ ok: true });
+}
+```
+
+### After
+
+```js
+import { json } from '@sveltejs/kit';
+import { createProjectUpdate } from '$lib/server/service/projectUpdatesService.js';
+
+export async function POST({ params, request, locals }) {
+  const { title, body } = await request.json();
+
+  await createProjectUpdate(
+    {
+      projectId: params.id,
+      title,
+      body,
+      userId: locals.authUser.id
+    },
+    {
+      db: locals.db,
+      authUser: locals.authUser
+    }
+  );
+
+  return json({ ok: true });
+}
+```
+
+```js
+import { storeProjectUpdate } from '$lib/server/repo/projectUpdatesRepo.js';
+
+export async function createProjectUpdate(input, ctx) {
+  return storeProjectUpdate(
+    {
+      project_id: input.projectId,
+      title: input.title,
+      body: input.body,
+      user_id: input.userId
+    },
+    ctx.db
+  );
+}
+```
+
+## Alternatives Considered
+
+### 1. Keep `locals.supabase` as the route-level dependency
+
+Rejected.
+
+This keeps routes coupled to a vendor client and makes migration noisier than it needs to be.
+
+### 2. Pass raw `locals` into services
+
+Rejected.
+
+This makes services depend on SvelteKit request objects and weakens testability.
+
+### 3. Build request-scoped service factories in `hooks.server.js`
+
+Rejected for now.
+
+This keeps routes very clean, but it adds per-request wiring and indirection that is not justified for the current codebase.
+
+### 4. Let repositories import a global Supabase client internally
+
+Rejected.
+
+This reduces ceremony, but it introduces hidden dependencies and weakens request scoping, testability, and portability.
+
+## Consequences
+
+### Positive
+
+- routes depend on service functions instead of vendor clients
+- services stay framework-agnostic
+- repositories stay the persistence boundary
+- replacing Supabase later touches fewer files
+- route and service tests can inject a fake `db` without mocking global clients
+
+### Negative
+
+- routes still construct a small dependency object
+- repository functions continue to take an explicit dependency parameter
+- the codebase may temporarily contain both old and new patterns during migration
+
+## Testing Impact
+
+This decision makes tests simpler.
+
+Route tests can stub a small request context object.
+Service tests can call service functions with a fake `db`.
+Repository tests can focus on query behavior without mocking route or framework state.
+
+## Standard Request Context
+
+The current standard request context is:
+
+```js
+/**
+ * @typedef {object} RequestContext
+ * @property {any} db
+ * @property {any | null | undefined} authUser
+ */
+```
+
+This matches current usage in the codebase.
+If future services need more request-scoped data, the context can be extended deliberately.
+
+Each service should document the subset it relies on with JSDoc.
+
+## Adoption Notes
+
+This ADR is not implemented yet.
+
+The intended migration path is:
+
+1. stop adding new route-level uses of `locals.supabase`
+2. introduce a neutral request context shape
+3. update routes to call services with that context
+4. keep repository functions as the explicit boundary for database access

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,102 @@
+# ADR Guide
+
+## Purpose
+
+Architectural Decision Records capture long-lived engineering decisions that should remain visible after a PR is merged.
+
+They exist to reduce drift, make tradeoffs explicit, and give future contributors a stable record of why a pattern or boundary exists.
+
+## When to Create an ADR
+
+Create an ADR when a change:
+
+- sets or changes a cross-cutting architectural direction
+- establishes a reusable engineering rule or boundary
+- introduces a pattern that future contributors are expected to follow
+- chooses between meaningful alternatives with real tradeoffs
+- is likely to be referenced in future implementation or review work
+
+## When Not to Create an ADR
+
+Do not create an ADR for:
+
+- temporary planning notes
+- one-off cleanup plans
+- implementation checklists
+- narrow feature specs that only matter for the current PR
+- routine code changes that do not set a lasting architectural rule
+
+If the document only exists to help execute one bounded change, put it in the PR description instead.
+
+## Required Sections
+
+Every ADR should include:
+
+- title
+- status
+- date
+- context
+- decision
+- alternatives considered
+- consequences
+
+Optional sections are allowed when useful:
+
+- examples
+- testing impact
+- adoption notes
+- migration notes
+
+## Status Values
+
+Use one of these statuses:
+
+- `Proposed`
+- `Accepted`
+- `Rejected`
+- `Superseded`
+
+Use `Proposed` when the decision is under review.
+Use `Accepted` when the decision is agreed, even if implementation is still incomplete.
+Use `Superseded` when a newer ADR replaces it.
+
+Implementation progress should usually be tracked in issues, PRs, or roadmap docs, not in the ADR status.
+
+## Naming and Numbering
+
+Use this filename pattern:
+
+`0001-short-kebab-case-title.md`
+
+Rules:
+
+- use a 4-digit numeric prefix
+- keep titles short and descriptive
+- do not rename existing ADR numbers after merge
+- create the next number in sequence
+
+## Workflow
+
+1. Decide whether the change is architectural.
+2. Check whether an ADR already exists for that area.
+3. If an ADR exists, follow it unless the task explicitly changes that decision.
+4. If the code needs a different direction, update the existing ADR or add a new ADR that supersedes it.
+5. If no ADR exists and the decision is long-lived, create a new ADR from `TEMPLATE.md`.
+6. Reference the ADR in the PR when the implementation depends on it.
+
+## How ADRs Should Be Used
+
+- Routes, services, repositories, and other cross-cutting patterns should follow relevant accepted ADRs.
+- Do not silently drift from an accepted ADR in implementation.
+- If implementation reveals the ADR is wrong or incomplete, call that out directly and update the ADR.
+- ADRs are the source of truth for architectural direction, not for feature scope or step-by-step execution.
+
+## Relationship to PRs
+
+- Use the PR description for bounded implementation specs by default.
+- Use an ADR when the decision should outlive the current PR.
+- A PR can implement an ADR, propose an ADR, or change an ADR.
+
+## Template
+
+Use [TEMPLATE.md](./TEMPLATE.md) when creating a new ADR.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,52 @@
+# ADR XXXX: Short Title
+
+## Status
+
+Proposed
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+Describe the current situation and the problem being solved.
+Explain why the decision matters and what constraints apply.
+
+## Decision
+
+State the decision clearly and directly.
+Describe the intended boundary, rule, or pattern.
+
+Include a small code example if it materially clarifies the decision.
+
+## Alternatives Considered
+
+### 1. Option name
+
+Accepted or rejected, with a short reason.
+
+### 2. Option name
+
+Accepted or rejected, with a short reason.
+
+## Consequences
+
+### Positive
+
+- expected benefit
+- expected benefit
+
+### Negative
+
+- cost or tradeoff
+- cost or tradeoff
+
+## Optional Sections
+
+Add these only when useful:
+
+- testing impact
+- migration notes
+- adoption notes
+- before/after examples


### PR DESCRIPTION
## Summary
- add ADR 0001 for request context abstraction
- define the route -> service -> repo dependency flow
- document the standard request context shape for current usage

## Decision
- routes import service functions directly
- services import repositories directly
- routes pass a small request context object
- services do not accept raw SvelteKit `locals`
- repositories remain the persistence boundary and receive the database dependency

## Notes
- this ADR is proposed, not implemented
- current standard request context is `db` and `authUser`
