### PR TITLE
add `ON DELETE` constraints

### DIFF
--- a/db/schema/add_on_delete_constraints.sql
+++ b/db/schema/add_on_delete_constraints.sql
@@ -1,0 +1,62 @@
+ALTER TABLE projects
+DROP CONSTRAINT projects_user_id_fkey,
+ADD CONSTRAINT projects_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;
+
+ALTER TABLE bookmark_project
+DROP CONSTRAINT bookmark_project_user_id_fkey,
+ADD CONSTRAINT bookmark_project_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;
+
+ALTER TABLE profile
+DROP CONSTRAINT profile_user_id_fkey,
+ADD CONSTRAINT profile_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;
+
+ALTER TABLE evaluation_queue
+DROP CONSTRAINT evaluation_queue_requested_by_fkey,
+ADD CONSTRAINT evaluation_queue_requested_by_fkey
+FOREIGN KEY (requested_by)
+REFERENCES auth.users(id)
+ON DELETE SET NULL;
+
+ALTER TABLE project_members
+DROP CONSTRAINT project_members_user_id_fkey,
+ADD CONSTRAINT project_members_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;
+
+ALTER TABLE project_members
+DROP CONSTRAINT project_members_creator_id_fkey,
+ADD CONSTRAINT project_members_creator_id_fkey
+FOREIGN KEY (creator_id)
+REFERENCES auth.users(id)
+ON DELETE SET NULL;
+
+ALTER TABLE project_resource
+DROP CONSTRAINT project_resource_user_id_fkey,
+ADD CONSTRAINT project_resource_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES auth.users(id)
+ON DELETE SET NULL;
+
+ALTER TABLE project_updates
+DROP CONSTRAINT project_updates_user_id_fkey,
+ADD CONSTRAINT project_updates_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES auth.users(id)
+ON DELETE SET NULL;
+
+ALTER TABLE project_update_comment
+DROP CONSTRAINT project_update_comment_user_id_fkey,
+ADD CONSTRAINT project_update_comment_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES auth.users(id)
+ON DELETE SET NULL;

--- a/db/schema/add_on_delete_constraints.sql
+++ b/db/schema/add_on_delete_constraints.sql
@@ -1,3 +1,4 @@
+-- User-owned rows
 ALTER TABLE projects
 DROP CONSTRAINT projects_user_id_fkey,
 ADD CONSTRAINT projects_user_id_fkey
@@ -60,3 +61,60 @@ ADD CONSTRAINT project_update_comment_user_id_fkey
 FOREIGN KEY (user_id)
 REFERENCES auth.users(id)
 ON DELETE SET NULL;
+
+-- Project-owned rows
+ALTER TABLE bookmark_project
+DROP CONSTRAINT bookmark_project_project_id_fkey,
+ADD CONSTRAINT bookmark_project_project_id_fkey
+FOREIGN KEY (project_id)
+REFERENCES projects(id)
+ON DELETE CASCADE;
+
+ALTER TABLE category_project
+DROP CONSTRAINT category_project_project_id_fkey,
+ADD CONSTRAINT category_project_project_id_fkey
+FOREIGN KEY (project_id)
+REFERENCES projects(id)
+ON DELETE CASCADE;
+
+ALTER TABLE project_dpg_status
+DROP CONSTRAINT project_dpg_status_project_id_fkey,
+ADD CONSTRAINT project_dpg_status_project_id_fkey
+FOREIGN KEY (project_id)
+REFERENCES projects(id)
+ON DELETE CASCADE;
+
+ALTER TABLE project_members
+DROP CONSTRAINT project_members_project_id_fkey,
+ADD CONSTRAINT project_members_project_id_fkey
+FOREIGN KEY (project_id)
+REFERENCES projects(id)
+ON DELETE CASCADE;
+
+ALTER TABLE project_resource
+DROP CONSTRAINT project_resource_project_id_fkey,
+ADD CONSTRAINT project_resource_project_id_fkey
+FOREIGN KEY (project_id)
+REFERENCES projects(id)
+ON DELETE CASCADE;
+
+ALTER TABLE project_updates
+DROP CONSTRAINT project_updates_project_id_fkey,
+ADD CONSTRAINT project_updates_project_id_fkey
+FOREIGN KEY (project_id)
+REFERENCES projects(id)
+ON DELETE CASCADE;
+
+ALTER TABLE project_update_comment
+DROP CONSTRAINT project_update_comment_project_id_fkey,
+ADD CONSTRAINT project_update_comment_project_id_fkey
+FOREIGN KEY (project_id)
+REFERENCES projects(id)
+ON DELETE CASCADE;
+
+ALTER TABLE project_update_comment
+DROP CONSTRAINT project_update_comment_update_id_fkey,
+ADD CONSTRAINT project_update_comment_update_id_fkey
+FOREIGN KEY (update_id)
+REFERENCES project_updates(id)
+ON DELETE CASCADE;


### PR DESCRIPTION
Just noticed and debugged a painful bug in the schema 
when we create a new user, and try to delete it, it never gets deleted.
postgres doesnt allow it - mainly due to our schema not having the `ON DELETE` action

we have a lot of foreign keys pointing to `auth.users(id)`, but none of them specify `ON DELETE CASCADE` or something else.
That means:
- Supabase tries to delete a user (even from dashboard)
- Postgres blocks it because other tables still reference that user
- Supabase returns 500 error

we reference `auth.users(id)` in many places:

`projects.user_id`
`bookmark_project.user_id`
`profile.user_id`
`evaluation_queue.requested_by`
`project_members.user_id`
`project_members.creator_id`
`project_resource.user_id`
`project_updates.user_id`
`project_update_comment.user_id`

**ALL** of these block deletion