### PR TITLE
feat: rank explore Top Projects by DPG readiness

### DIFF
--- a/src/lib/server/repo/projectRepo.js
+++ b/src/lib/server/repo/projectRepo.js
@@ -12,7 +12,9 @@ export async function getProjects(term, start, end, supabase) {
   return data || [];
 }
 
-export async function getProjectsWithCategories(term, start, end, supabase) {
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function getProjectsWithCategories(term, start, end, supabase, excludeIds = []) {
   let query = supabase.from('projects').select(
     `
       id,
@@ -38,12 +40,52 @@ export async function getProjectsWithCategories(term, start, end, supabase) {
   // Only show published projects on explore page
   query = query.not('published_at', 'is', null);
 
+  // Exclude projects already surfaced in the Top Projects hero.
+  // Filter to UUID-shaped values so user-supplied strings can't reach PostgREST.
+  const safeExcludeIds = Array.isArray(excludeIds)
+    ? excludeIds.filter((id) => UUID_RE.test(id))
+    : [];
+  if (safeExcludeIds.length > 0) {
+    query = query.not('id', 'in', `(${safeExcludeIds.join(',')})`);
+  }
+
   // Conditionally add search filter only if term is provided
   if (term && term.trim() !== '') {
     query = query.ilike('title', `%${term}%`);
   }
 
   const { data, error } = await query.range(start, end).order('created_at', { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return data || [];
+}
+
+export async function getPublishedProjectsWithDpgStatus(supabase) {
+  const { data, error } = await supabase
+    .from('projects')
+    .select(
+      `
+      id,
+      title,
+      banner_image,
+      funding_goal,
+      current_funding,
+      user_id,
+      bio,
+      published_at,
+      dpgStatus,
+      category_project!inner (
+        categories!inner (
+          id,
+          sdg_id,
+          title,
+          image
+        )
+      )
+    `,
+    )
+    .not('published_at', 'is', null)
+    .order('created_at', { ascending: false });
 
   if (error) throw new Error(error.message);
   return data || [];

--- a/src/lib/server/service/projectService.js
+++ b/src/lib/server/service/projectService.js
@@ -10,6 +10,7 @@ import {
   getProjectsWithCategories,
   getProjectsByUserIdWithCategories,
   getProjectsByUserIdWithContributions,
+  getPublishedProjectsWithDpgStatus,
 } from '$lib/server/repo/projectRepo.js';
 import { createTeamMember, teamMembers } from '$lib/server/repo/memberRepo.js';
 import {
@@ -28,11 +29,11 @@ import { getExistingBookmarksByUserId } from '$lib/server/repo/bookmarkRepo.js';
 import { mapProjectsWithTagsAndStatus } from './helpers/projectHelpers.js';
 import { requestEvaluation } from '$lib/server/service/evaluationQueueService.js';
 
-export async function getProjectsWithDetails(term, page, limit, supabase) {
+export async function getProjectsWithDetails(term, page, limit, supabase, excludeIds = []) {
   const start = (page - 1) * limit;
   const end = start + limit - 1;
 
-  const projects = await getProjectsWithCategories(term, start, end, supabase);
+  const projects = await getProjectsWithCategories(term, start, end, supabase, excludeIds);
   return mapProjectsWithDetails(projects);
 }
 
@@ -56,6 +57,19 @@ function mapProjectsWithDetails(projects) {
       dpgCount: dpgTotalScore,
     };
   });
+}
+
+export async function getTopProjectsByReadiness(limit, supabase) {
+  const projects = await getPublishedProjectsWithDpgStatus(supabase);
+  const withDetails = mapProjectsWithDetails(projects);
+
+  // Exclude fully-ready projects — Top Projects is a "closest-to-ready" spotlight.
+  const notYetReady = withDetails.filter((p) => p.dpgCount < 9);
+
+  // Stable sort by dpgCount DESC; ties preserve repo ordering (created_at DESC).
+  notYetReady.sort((a, b) => b.dpgCount - a.dpgCount);
+
+  return notYetReady.slice(0, limit);
 }
 
 export async function getUserProjects(userId, page, limit, supabase) {

--- a/src/lib/server/service/projectService.test.js
+++ b/src/lib/server/service/projectService.test.js
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/repo/projectRepo.js', () => ({
+  getProject: vi.fn(),
+  getProjects: vi.fn(),
+  createProject: vi.fn(),
+  updateDetails: vi.fn(),
+  getProjectsByUserId: vi.fn(),
+  getProjectsByIds: vi.fn(),
+  getProjectByGithub: vi.fn(),
+  getProjectsWithCategories: vi.fn(),
+  getProjectsByUserIdWithCategories: vi.fn(),
+  getProjectsByUserIdWithContributions: vi.fn(),
+  getPublishedProjectsWithDpgStatus: vi.fn(),
+}));
+
+vi.mock('$lib/server/repo/memberRepo.js', () => ({
+  createTeamMember: vi.fn(),
+  teamMembers: vi.fn(),
+}));
+
+vi.mock('$lib/server/repo/categoryRepo.js', () => ({
+  assignCategory: vi.fn(),
+  getCategories: vi.fn(),
+  getProjectCategories: vi.fn(),
+  getProjectsByCategoryId: vi.fn(),
+  addTags: vi.fn(),
+  getProjectExistingCategories: vi.fn(),
+  removeTags: vi.fn(),
+  getProjectsByCategoriesWithPagination: vi.fn(),
+}));
+
+vi.mock('../repo/dpgStatusRepo.js', () => ({
+  getDpgStatuses: vi.fn(),
+}));
+
+vi.mock('$lib/server/repo/userProfileRepo.js', () => ({
+  getMultipleProfiles: vi.fn(),
+}));
+
+vi.mock('$lib/server/repo/bookmarkRepo.js', () => ({
+  getExistingBookmarksByUserId: vi.fn(),
+}));
+
+vi.mock('$lib/server/service/evaluationQueueService.js', () => ({
+  requestEvaluation: vi.fn(),
+}));
+
+import { getPublishedProjectsWithDpgStatus } from '$lib/server/repo/projectRepo.js';
+import { getTopProjectsByReadiness } from './projectService.js';
+
+/** Builds a project with the given met-criteria count (0..9). Omit `met` for unevaluated. */
+function project(id, { met, title } = {}) {
+  const base = {
+    id,
+    title: title ?? `Project ${id}`,
+    banner_image: null,
+    funding_goal: 0,
+    current_funding: 0,
+    user_id: 'u1',
+    bio: '',
+    published_at: '2026-01-01T00:00:00Z',
+    category_project: [],
+  };
+  if (typeof met === 'number') {
+    base.dpgStatus = {
+      status: Array.from({ length: 9 }, (_, i) => ({ overallScore: i < met ? 1 : 0 })),
+    };
+  }
+  return base;
+}
+
+describe('getTopProjectsByReadiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sorts by dpgCount DESC', async () => {
+    getPublishedProjectsWithDpgStatus.mockResolvedValue([
+      project('a', { met: 3 }),
+      project('b', { met: 7 }),
+      project('c', { met: 5 }),
+    ]);
+
+    const result = await getTopProjectsByReadiness(3, {});
+
+    expect(result.map((p) => p.id)).toEqual(['b', 'c', 'a']);
+    expect(result.map((p) => p.dpgCount)).toEqual([7, 5, 3]);
+  });
+
+  it('excludes fully-ready (9/9) projects', async () => {
+    getPublishedProjectsWithDpgStatus.mockResolvedValue([
+      project('ready', { met: 9 }),
+      project('nearly', { met: 8 }),
+      project('early', { met: 2 }),
+    ]);
+
+    const result = await getTopProjectsByReadiness(5, {});
+
+    expect(result.map((p) => p.id)).toEqual(['nearly', 'early']);
+    expect(result.find((p) => p.id === 'ready')).toBeUndefined();
+  });
+
+  it('includes unevaluated projects counted as 0', async () => {
+    getPublishedProjectsWithDpgStatus.mockResolvedValue([
+      project('unevaluated'),
+      project('mid', { met: 4 }),
+    ]);
+
+    const result = await getTopProjectsByReadiness(5, {});
+
+    expect(result.map((p) => p.id)).toEqual(['mid', 'unevaluated']);
+    expect(result.find((p) => p.id === 'unevaluated').dpgCount).toBe(0);
+  });
+
+  it('respects the limit', async () => {
+    getPublishedProjectsWithDpgStatus.mockResolvedValue([
+      project('a', { met: 8 }),
+      project('b', { met: 7 }),
+      project('c', { met: 6 }),
+      project('d', { met: 5 }),
+    ]);
+
+    const result = await getTopProjectsByReadiness(2, {});
+
+    expect(result.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  it('preserves input order on ties (stable sort)', async () => {
+    // Repo returns by created_at DESC, so "first in" = most recent.
+    getPublishedProjectsWithDpgStatus.mockResolvedValue([
+      project('recent-tie', { met: 6 }),
+      project('older-tie', { met: 6 }),
+      project('low', { met: 1 }),
+    ]);
+
+    const result = await getTopProjectsByReadiness(3, {});
+
+    expect(result.map((p) => p.id)).toEqual(['recent-tie', 'older-tie', 'low']);
+  });
+});

--- a/src/routes/api/projects/+server.js
+++ b/src/routes/api/projects/+server.js
@@ -8,10 +8,16 @@ export async function GET({ url, locals, setHeaders }) {
   const page = parseInt(url.searchParams.get('page') || '1', 10);
   const limit = parseInt(url.searchParams.get('limit') || '6', 10);
   const term = url.searchParams.get('term') || '';
+  const excludeIds =
+    url.searchParams
+      .get('excludeIds')
+      ?.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean) || [];
   let supabase = locals.supabase;
 
   try {
-    const projects = await getProjectsWithDetails(term, page, limit, supabase);
+    const projects = await getProjectsWithDetails(term, page, limit, supabase, excludeIds);
 
     return json({ projects: projects }, { status: 200 });
   } catch (error) {

--- a/src/routes/api/projects/top/+server.js
+++ b/src/routes/api/projects/top/+server.js
@@ -1,0 +1,23 @@
+//@ts-check
+
+import { getTopProjectsByReadiness } from '$lib/server/service/projectService.js';
+import { json } from '@sveltejs/kit';
+
+const DEFAULT_LIMIT = 3;
+const MAX_LIMIT = 20;
+
+export async function GET({ url, locals }) {
+  const parsed = parseInt(url.searchParams.get('limit') || String(DEFAULT_LIMIT), 10);
+  const limit = Math.min(
+    Math.max(Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LIMIT, 1),
+    MAX_LIMIT,
+  );
+  const supabase = locals.supabase;
+
+  try {
+    const projects = await getTopProjectsByReadiness(limit, supabase);
+    return json({ projects }, { status: 200 });
+  } catch (error) {
+    return json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/routes/explore/+page.js
+++ b/src/routes/explore/+page.js
@@ -5,11 +5,19 @@ export async function load({ url, fetch }) {
   const currentPage = url.searchParams.get('page') || 1;
   const itemsPerPage = url.searchParams.get('limit') || 6;
 
+  // Fetch top first so we can exclude those IDs from the paginated list below —
+  // prevents the same project from appearing in both sections.
+  const { projects: topProjects } =
+    await fetch(`/api/projects/top?limit=3`).then(parseJsonResponse);
+
+  const excludeParam = topProjects.length
+    ? `&excludeIds=${topProjects.map((p) => p.id).join(',')}`
+    : '';
   const { projects: allProjects } = await fetch(
-    `/api/projects?page=${currentPage}&limit=${itemsPerPage}`,
+    `/api/projects?page=${currentPage}&limit=${itemsPerPage}${excludeParam}`,
   ).then(parseJsonResponse);
 
-  return { allProjects, topProjects: allProjects.slice(0, 3) };
+  return { allProjects, topProjects };
 }
 
 const parseJsonResponse = (res) => {

--- a/src/routes/explore/+page.svelte
+++ b/src/routes/explore/+page.svelte
@@ -11,6 +11,9 @@
 
   export let data;
   let loadedProjects = data.allProjects;
+  // Keep paginated list in sync with the initial server load: exclude projects
+  // already surfaced in the Top Projects hero so they don't appear twice.
+  const topProjectIds = (data.topProjects ?? []).map((p) => p.id);
 
   let searchResults = [];
   let categoryResult = [];
@@ -31,12 +34,16 @@
   // TODO: we would find a way around it later
   async function fetchAllProjects() {
     try {
-      const response = await fetch(`/api/projects?page=${currentPage}&limit=${itemsPerPage}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
+      const excludeParam = topProjectIds.length ? `&excludeIds=${topProjectIds.join(',')}` : '';
+      const response = await fetch(
+        `/api/projects?page=${currentPage}&limit=${itemsPerPage}${excludeParam}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
         },
-      });
+      );
 
       if (!response.ok) {
         throw new Error(response.statusText);


### PR DESCRIPTION
## Summary

- `/explore` Top Projects now ranks by `dpgCount` DESC, excluding fully-ready (9/9) projects. The hero slot spotlights projects closest to DPG-ready — where visibility has the most leverage.
- Unevaluated projects are counted as `0/9` and naturally fall to the bottom (no hard filter).
- Paginated list below excludes the 3 Top Projects on **every page** (initial load + "Load more") so nothing appears twice.

### Before / after (dev data)

| Rank | Before (recency) | After (readiness) |
|---|---|---|
| 1 | 8/9 UniNotepad | 8/9 UniNotepad |
| 2 | 2/9 KACCP | **8/9 Pipeline** |
| 3 | 5/9 SDSL OpenCollege | 5/9 SDSL OpenCollege |

Pipeline (published mid-March, 8/9) is now promoted above newer-but-lower-scored projects.

### Implementation notes

- New repo fn `getPublishedProjectsWithDpgStatus` fetches the full published corpus so ranking isn't constrained to page 1.
- New service fn `getTopProjectsByReadiness` reuses the existing `dpgCount` computation from `mapProjectsWithDetails`, filters 9/9, stable-sorts desc, slices.
- New endpoint `GET /api/projects/top?limit=` with limit clamped to `[1, 20]`.
- `getProjectsWithCategories` gains an `excludeIds` param (UUID-shape validated before reaching PostgREST).
- Explore load sequences: fetch top first, then all-projects with `excludeIds=top.ids`. ~20–50ms extra latency for the dedupe guarantee.

## Test plan

- [ ] `npx vitest run src/lib/server/service/projectService.test.js` — 5 tests pass (sort DESC, exclude 9/9, include unevaluated as 0, respect limit, stable ties)
- [ ] Load `/explore`: Top Projects shows highest-readiness non-9/9 projects
- [ ] None of the Top Projects appear in the paginated list below
- [ ] Click "Load more" — top projects still don't reappear on later pages
- [ ] `curl /api/projects/top?limit=abc` / `?limit=-5` / `?limit=999` → sensibly clamped to default/max