### PR TITLE
fix: filter category views to published projects only

### DIFF
--- a/src/lib/server/repo/categoryRepo.js
+++ b/src/lib/server/repo/categoryRepo.js
@@ -38,7 +38,7 @@ export async function getProjectsByCategoriesWithPagination(categoryIds, start, 
     .select(
       `
       project_id,
-      projects (id,
+      projects!inner (id,
       title,
       banner_image,
       funding_goal,
@@ -58,6 +58,7 @@ export async function getProjectsByCategoriesWithPagination(categoryIds, start, 
     `,
     )
     .in('category_id', categoryIds)
+    .not('projects.published_at', 'is', null)
     .range(start, end);
 
   if (error) throw new Error(error.message);


### PR DESCRIPTION
getProjectsByCategoriesWithPagination returned every project in a selected category, including unpublished ones — so applying a category filter on explore surfaced drafts that would otherwise be hidden by the default feed.

Switch the `projects` embed to an inner join and add `.not('projects.published_at', 'is', null)` so the filtered view matches getProjectsWithCategories and getPublishedProjectsWithDpgStatus, which already restrict results to published projects.