### PR TITLE
fix: reconcile projects.github column with deployed schema

### DIFF
--- a/db/migrations/004_rename_github_repo_to_github.sql
+++ b/db/migrations/004_rename_github_repo_to_github.sql
@@ -1,0 +1,36 @@
+-- 004_rename_github_repo_to_github.sql
+-- Aligns projects.github_repo with the column name used by the application
+-- (validator, repo, service, and API routes all reference projects.github).
+-- Safe to run multiple times (idempotent).
+
+DO $$
+DECLARE
+  has_github boolean;
+  has_github_repo boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'projects' AND column_name = 'github'
+  ) INTO has_github;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'projects' AND column_name = 'github_repo'
+  ) INTO has_github_repo;
+
+  IF NOT has_github AND has_github_repo THEN
+    -- Rename the legacy column in place, preserving any existing data.
+    ALTER TABLE public.projects RENAME COLUMN github_repo TO github;
+  ELSIF NOT has_github AND NOT has_github_repo THEN
+    -- Fresh database that never had either column.
+    ALTER TABLE public.projects ADD COLUMN github text NULL;
+  ELSIF has_github AND has_github_repo THEN
+    -- Both exist (mid-migration state). Backfill nulls from the legacy
+    -- column, then drop it so future inserts only target `github`.
+    UPDATE public.projects
+       SET github = github_repo
+     WHERE github IS NULL AND github_repo IS NOT NULL;
+    ALTER TABLE public.projects DROP COLUMN github_repo;
+  END IF;
+  -- If only `github` exists, there is nothing to do.
+END $$;

--- a/db/schema/schema.sql
+++ b/db/schema/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS public.projects (
     user_id uuid NULL,
     title text NULL,
     bio text NULL,
-    github_repo text NULL,
+    github text NULL,
     funding_goal double precision NULL,
     current_funding double precision NULL,
     status text NULL,


### PR DESCRIPTION
## Summary

`db/schema/schema.sql` declared `projects.github_repo`, but every code path in the app reads/writes `projects.github`:

- validator: `src/lib/server/validator/projectSchema.js:49`
- repo: `src/lib/server/repo/projectRepo.js:194` (`getProjectByGithub`)
- service insert: `src/lib/server/service/projectService.js:212` (`storeProject`)
- evaluation route: `src/routes/api/projects/[id]/evaluate/+server.js`
- webhook service: `src/lib/server/service/githubWebhookService.js`

A fresh database bootstrapped from `schema.sql` therefore fails every project query with `column projects.github does not exist`. The deployed DB has `github` (the comment at `src/routes/api/projects/[id]/github/issues/+server.js:16-19` already calls this out as schema-vs-code drift), but the SQL file was never updated to match.

This PR reconciles the SQL file with the deployed shape and ships an idempotent migration so existing databases converge correctly.

This addresses the **Field note** flagged in `docs/V2_QUICK_WINS.md`:
> `projects.github_repo` vs `project.github` mismatch ... the SQL file should be reconciled with what production actually runs.

## Changes

- `db/schema/schema.sql` — `github_repo text NULL` → `github text NULL` so a fresh DB matches the application code.
- `db/migrations/004_rename_github_repo_to_github.sql` — new migration. Inspects `information_schema.columns` and handles all four states:
  - only `github_repo` exists → `RENAME COLUMN` (preserves data)
  - neither exists → `ADD COLUMN github`
  - both exist → backfill nulls from `github_repo`, then drop it
  - only `github` exists → no-op

  Safe to run multiple times.

## Test plan

- [ ] Run `db/migrations/004_rename_github_repo_to_github.sql` in Supabase SQL editor against a database that already has `github`. Verify it's a no-op (no error).
- [ ] In a scratch DB: create `projects` with `github_repo` only, run the migration, verify the column is now named `github` and data is preserved.
- [ ] In a scratch DB: create `projects` with both `github` and `github_repo` (with overlapping nullability), run the migration, verify nulls in `github` are backfilled from `github_repo` and `github_repo` is dropped.
- [ ] Bootstrap a fresh local DB from the updated `db/schema/schema.sql`. Create a project from the UI; verify it inserts without the `column projects.github does not exist` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)