### PR TITLE
feat: Slice 8 — Recent Activity tab on profile page

### DIFF
--- a/src/lib/server/repo/activityRepo.js
+++ b/src/lib/server/repo/activityRepo.js
@@ -1,0 +1,111 @@
+//@ts-check
+
+export async function getUserActivity(userId, limit = 20, supabase) {
+  const [
+    { data: created, error: e1 },
+    { data: contributions, error: e2 },
+    { data: bookmarks, error: e3 },
+    { data: updates, error: e4 },
+    { data: comments, error: e5 },
+  ] = await Promise.all([
+    supabase
+      .from('projects')
+      .select('id, title, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+    supabase
+      .from('project_resource')
+      .select('project_id, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+    supabase
+      .from('bookmark_project')
+      .select('project_id, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+    supabase
+      .from('project_updates')
+      .select('title, project_id, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+    supabase
+      .from('project_update_comment')
+      .select('project_id, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit),
+  ]);
+
+  if (e1) throw new Error(e1.message);
+  if (e2) throw new Error(e2.message);
+  if (e3) throw new Error(e3.message);
+  if (e4) throw new Error(e4.message);
+  if (e5) throw new Error(e5.message);
+
+  // Seed from created projects to avoid re-fetching titles for projects the user both created and interacted with
+  const projectTitles = new Map();
+  (created || []).forEach((p) => projectTitles.set(p.id, p.title));
+
+  // Fetch titles for any project IDs not already covered by the created query
+  const missingIds = [
+    ...(contributions || []).map((r) => r.project_id),
+    ...(bookmarks || []).map((b) => b.project_id),
+    ...(updates || []).map((u) => u.project_id),
+    ...(comments || []).map((c) => c.project_id),
+  ].filter((id) => id && !projectTitles.has(id));
+
+  if (missingIds.length > 0) {
+    const uniqueMissingIds = [...new Set(missingIds)];
+    const { data: projects, error: pe } = await supabase
+      .from('projects')
+      .select('id, title')
+      .in('id', uniqueMissingIds);
+    if (pe) throw new Error(pe.message);
+    (projects || []).forEach((p) => projectTitles.set(p.id, p.title));
+  }
+
+  const activities = [
+    ...(created || []).map((p) => ({
+      type: 'created',
+      projectId: p.id,
+      projectTitle: p.title,
+      description: 'Created a project',
+      createdAt: p.created_at,
+    })),
+    ...(contributions || []).map((r) => ({
+      type: 'contributed',
+      projectId: r.project_id,
+      projectTitle: projectTitles.get(r.project_id) || null,
+      description: 'Submitted a contribution',
+      createdAt: r.created_at,
+    })),
+    ...(bookmarks || []).map((b) => ({
+      type: 'followed',
+      projectId: b.project_id,
+      projectTitle: projectTitles.get(b.project_id) || null,
+      description: 'Followed a project',
+      createdAt: b.created_at,
+    })),
+    ...(updates || []).map((u) => ({
+      type: 'update',
+      projectId: u.project_id,
+      projectTitle: projectTitles.get(u.project_id) || null,
+      description: u.title ? `Posted an update: "${u.title}"` : 'Posted a project update',
+      createdAt: u.created_at,
+    })),
+    ...(comments || []).map((c) => ({
+      type: 'comment',
+      projectId: c.project_id,
+      projectTitle: projectTitles.get(c.project_id) || null,
+      description: 'Commented on a project update',
+      createdAt: c.created_at,
+    })),
+  ];
+
+  activities.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  return activities.slice(0, limit);
+}

--- a/src/lib/server/service/activityService.js
+++ b/src/lib/server/service/activityService.js
@@ -1,0 +1,6 @@
+//@ts-check
+import { getUserActivity } from '$lib/server/repo/activityRepo.js';
+
+export async function getUserRecentActivity(userId, limit = 20, supabase) {
+  return getUserActivity(userId, limit, supabase);
+}

--- a/src/routes/api/profile/activity/+server.js
+++ b/src/routes/api/profile/activity/+server.js
@@ -1,0 +1,17 @@
+import { json } from '@sveltejs/kit';
+import { getUserRecentActivity } from '$lib/server/service/activityService.js';
+
+export async function GET({ url, locals }) {
+  const user = locals.authUser;
+  const supabase = locals.supabase;
+
+  const limitParam = parseInt(url.searchParams.get('limit') || '20', 10);
+  const limit = Math.min(Math.max(limitParam, 1), 50);
+
+  try {
+    const activities = await getUserRecentActivity(user.id, limit, supabase);
+    return json({ activities });
+  } catch (error) {
+    return json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/routes/profile/(profile)/+layout.svelte
+++ b/src/routes/profile/(profile)/+layout.svelte
@@ -40,12 +40,19 @@
       icon: 'mdi:heart',
       count: data.following?.length || 0,
     },
+    {
+      name: 'Recent Activity',
+      href: '/profile/activity',
+      icon: 'mdi:clock-outline',
+      count: 0,
+    },
   ];
 
   function getActiveTab(pathname) {
     if (pathname === '/profile') return 0;
     if (pathname.endsWith('/contributed')) return 1;
     if (pathname.endsWith('/following')) return 2;
+    if (pathname.endsWith('/activity')) return 3;
     return 0;
   }
 
@@ -203,7 +210,9 @@
                   Download My Data
                   <Icon icon="mdi:chevron-down" class="h-5 w-5" />
                 </DropdownMenu.Trigger>
-                <DropdownMenu.Content class="z-50 min-w-[180px] rounded-xl border border-dashboard-gray-700 bg-dashboard-gray-900 p-1 text-white">
+                <DropdownMenu.Content
+                  class="z-50 min-w-[180px] rounded-xl border border-dashboard-gray-700 bg-dashboard-gray-900 p-1 text-white"
+                >
                   <DropdownMenu.Item
                     class="cursor-pointer rounded-lg px-3 py-2 text-sm hover:bg-dashboard-gray-800"
                     on:click={() => downloadMyData('json')}

--- a/src/routes/profile/(profile)/activity/+page.svelte
+++ b/src/routes/profile/(profile)/activity/+page.svelte
@@ -1,0 +1,122 @@
+<script>
+  import { onMount } from 'svelte';
+  import Icon from '@iconify/svelte';
+  import { timeAgo } from '$lib/utils/dateTimeFormat.js';
+
+  let activities = [];
+  let loading = true;
+  let error = null;
+
+  const typeConfig = {
+    created: {
+      icon: 'mdi:folder-plus',
+      color: 'text-dashboard-purple-500',
+      bg: 'bg-dashboard-purple-500/10',
+    },
+    contributed: { icon: 'mdi:account-group', color: 'text-blue-400', bg: 'bg-blue-400/10' },
+    followed: { icon: 'mdi:heart', color: 'text-pink-400', bg: 'bg-pink-400/10' },
+    update: {
+      icon: 'mdi:newspaper-variant-outline',
+      color: 'text-dashboard-success-500',
+      bg: 'bg-dashboard-success-500/10',
+    },
+    comment: {
+      icon: 'mdi:comment-outline',
+      color: 'text-dashboard-yellow-400',
+      bg: 'bg-dashboard-yellow-400/10',
+    },
+  };
+
+  onMount(async () => {
+    try {
+      const res = await fetch('/api/profile/activity?limit=50');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to load activity');
+      activities = data.activities || [];
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+{#if loading}
+  <div class="space-y-4">
+    {#each Array(5) as _}
+      <div
+        class="flex animate-pulse items-start gap-4 rounded-2xl border border-dashboard-gray-700 bg-dashboard-gray-900/50 p-5"
+      >
+        <div class="h-10 w-10 flex-shrink-0 rounded-full bg-dashboard-gray-700"></div>
+        <div class="flex-1 space-y-2">
+          <div class="h-4 w-2/3 rounded bg-dashboard-gray-700"></div>
+          <div class="h-3 w-1/3 rounded bg-dashboard-gray-700"></div>
+        </div>
+      </div>
+    {/each}
+  </div>
+{:else if error}
+  <div class="flex min-h-[400px] items-center justify-center">
+    <div
+      class="rounded-2xl border border-dashboard-gray-700 bg-dashboard-gray-900/50 p-8 text-center"
+    >
+      <p class="text-body-md text-gray-400">{error}</p>
+    </div>
+  </div>
+{:else if activities.length === 0}
+  <div class="flex min-h-[400px] items-center justify-center">
+    <div class="max-w-md text-center">
+      <div
+        class="mb-6 rounded-2xl border border-dashboard-gray-700 bg-dashboard-gray-900/50 p-8 backdrop-blur-sm"
+      >
+        <div
+          class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-dashboard-gray-800"
+        >
+          <Icon icon="mdi:clock-outline" class="h-8 w-8 text-gray-500" />
+        </div>
+        <h3 class="mb-2 text-heading-lg text-white">No activity yet</h3>
+        <p class="mb-6 text-body-md text-gray-400">
+          Your activity will appear here as you create projects, contribute, and engage with the
+          community.
+        </p>
+        <a href="/explore">
+          <button
+            class="focus-ring mx-auto flex items-center justify-center gap-2 rounded-xl bg-dashboard-purple-500 px-6 py-3 text-label-lg font-medium text-white transition-all duration-200 hover:scale-105 hover:bg-dashboard-purple-600"
+          >
+            <Icon icon="mdi:compass-outline" class="h-5 w-5" />
+            Explore Projects
+          </button>
+        </a>
+      </div>
+    </div>
+  </div>
+{:else}
+  <div class="space-y-3">
+    {#each activities as activity}
+      {@const config = typeConfig[activity.type] || typeConfig.created}
+      <div
+        class="flex items-start gap-4 rounded-2xl border border-dashboard-gray-700 bg-dashboard-gray-900/50 p-5 backdrop-blur-sm transition-all duration-200 hover:border-dashboard-gray-600 hover:bg-dashboard-gray-900"
+      >
+        <div class="flex-shrink-0">
+          <div class="flex h-10 w-10 items-center justify-center rounded-full {config.bg}">
+            <Icon icon={config.icon} class="h-5 w-5 {config.color}" />
+          </div>
+        </div>
+        <div class="min-w-0 flex-1">
+          <p class="text-body-md text-gray-200">
+            {activity.description}
+            {#if activity.projectId && activity.projectTitle}
+              <a
+                href="/project/{activity.projectId}"
+                class="font-medium text-dashboard-yellow-400 transition-colors hover:text-dashboard-yellow-300"
+              >
+                {activity.projectTitle}
+              </a>
+            {/if}
+          </p>
+          <p class="mt-1 text-body-sm text-gray-500">{timeAgo(activity.createdAt)}</p>
+        </div>
+      </div>
+    {/each}
+  </div>
+{/if}


### PR DESCRIPTION
## Why this PR exists

Slice 8 of the [V2 quick wins](docs/V2_QUICK_WINS.md). The previous version of this PR introduced files that had already been removed from \`main\` (GitHub OAuth connections, settings page, github_connections schema). This is a clean reimplementation of the user-facing goal — a platform activity feed — using only what exists in \`main\`.

---

## What changed, and why

### Recent Activity tab on the profile page

**What:** A fourth tab on \`/profile\` — "Recent Activity" — that shows a unified, reverse-chronological feed of everything the authenticated user has done on the platform. Each item shows a type-coloured icon, an action sentence, a linked project title, and a relative timestamp.

Activity sources (all from existing tables, no new schema):

| Table | Event shown |
|---|---|
| \`projects\` | Created a project |
| \`project_resource\` | Submitted a contribution |
| \`bookmark_project\` | Followed a project |
| \`project_updates\` | Posted a project update |
| \`project_update_comment\` | Commented on a project update |

**Implementation:**
- \`src/lib/server/repo/activityRepo.js\` — five parallel Supabase queries (one per table), each limited to \`limit\` rows. Project titles are resolved in a single follow-up \`.in()\` query; the \`created\` query pre-seeds the title map to avoid re-fetching for projects the user both created and interacted with. Results are merged, sorted by \`created_at\` desc, and sliced.
- \`src/lib/server/service/activityService.js\` — thin service wrapper following the three-layer pattern.
- \`src/routes/api/profile/activity/+server.js\` — authenticated GET endpoint, \`?limit=\` param capped at 50.
- \`src/routes/profile/(profile)/activity/+page.svelte\` — client-side fetch on mount, loading skeleton, empty state, timeline feed. Uses existing \`timeAgo\` from \`\$lib/utils/dateTimeFormat.js\`.
- \`src/routes/profile/(profile)/+layout.svelte\` — adds the "Recent Activity" tab entry.

**Why:** Gives users visibility into their own contributions and engagement history from one place, without any new database tables or external API calls.

---

## Test plan

- [ ] \`npm run format\` clean
- [ ] \`npm run check\` clean (no new errors beyond pre-existing)
- [ ] Navigate to \`/profile\` — four tabs visible, "Recent Activity" is the fourth
- [ ] Click "Recent Activity" — feed loads with correct items after creating a project, contributing, or bookmarking
- [ ] Empty state renders correctly for a user with no activity
- [ ] Each activity item links to the correct project page
- [ ] Relative timestamps display correctly ("just now", "2 days ago", etc.)