### PR TITLE
load tags on create page

### DIFF
--- a/src/routes/project/ProjectBasics.svelte
+++ b/src/routes/project/ProjectBasics.svelte
@@ -17,6 +17,7 @@
   import { Popover, PopoverContent, PopoverTrigger } from '$lib/components/ui/popover';
 
   export let project = {};
+  export let availableTags = [];
 
   const countryList = Object.values(countries).sort((a, b) => a.name.localeCompare(b.name));
 
@@ -24,8 +25,6 @@
 
   let isOpen = false;
   let inputValue = '';
-
-  let availableTags = [];
 
   function toggleDropdown(event) {
     event.preventDefault();
@@ -88,11 +87,15 @@
 
       const data = await response.json();
       availableTags = data.categories;
-    } catch (error) {}
+    } catch (error) {
+      console.error('Failed to load project categories:', error);
+    }
   }
 
   onMount(async () => {
-    fetchAllCategories();
+    if (!availableTags.length) {
+      await fetchAllCategories();
+    }
   });
 </script>
 

--- a/src/routes/project/create/+page.server.js
+++ b/src/routes/project/create/+page.server.js
@@ -1,6 +1,21 @@
+import { allCategories } from '$lib/server/service/categoryService.js';
 import { createProjectSchema } from '$lib/server/validator/projectSchema.js';
 import { uploadImageAndReturnUrl } from '$lib/server/service/imageUploadService.js';
 import { error, fail, json, redirect } from '@sveltejs/kit';
+
+export async function load({ locals }) {
+  try {
+    return {
+      categories: await allCategories(locals.supabase),
+    };
+  } catch (error) {
+    console.error('Failed to load categories for project creation:', error);
+
+    return {
+      categories: [],
+    };
+  }
+}
 
 /** @type {import('./$types').Actions} */
 export const actions = {

--- a/src/routes/project/create/+page.svelte
+++ b/src/routes/project/create/+page.svelte
@@ -14,6 +14,8 @@
 
   import { goto } from '$app/navigation';
 
+  export let data;
+
   let loading = false;
   let loadingMatchingDPGs = false;
   let project = { title: '', bio: '' };
@@ -95,7 +97,7 @@
                 Tell us about your project and what makes it special
               </p>
             </div>
-            <ProjectBasics bind:project />
+            <ProjectBasics bind:project availableTags={data.categories} />
             <input type="hidden" name="matchedDPGs" value={JSON.stringify(matchProjects)} />
           </div>
         </div>


### PR DESCRIPTION
tags were not loaded because they depend on being fetch client side, and if an error occurs, the tags become empty and blank.
this PR loads the tags using the load function once the page loads so the tags are always available.
